### PR TITLE
version (token type) property in token record

### DIFF
--- a/lib/script/slp.js
+++ b/lib/script/slp.js
@@ -191,6 +191,7 @@ class SlpCoinRecord {
    * @param {String?} uri
    * @param {String?} hash
    * @param {Number} decimals
+   * @param {Number?} version
    */
 
   constructor(options = {}) {
@@ -201,6 +202,7 @@ class SlpCoinRecord {
     this.uri = options.uri || '';
     this.hash = options.hash || '';
     this.decimals = options.decimals;
+    this.version = options.version;
 
   }
 
@@ -223,7 +225,16 @@ class SlpCoinRecord {
     this.uri = br.readVarString('utf8');
     this.hash = br.readVarString('hex');
     this.decimals = br.readU8();
+    // Get version and handle if out of bounds
+    try {
+      this.version = br.readU8();
+    } catch(err) {
+      if (err.code === 'ERR_ENCODING') {
+        this.version = 1;
+      } else throw(err)
+    }
 
+    assert(this.version >= 1 && this.version <= 2);
     // assert(this.decimals >= 0 && this.decimals < 9);
 
     return this;
@@ -262,6 +273,7 @@ class SlpCoinRecord {
     if (this.hash.length === 0)
       bw.offset += encoding.sizeVarint(0);
     bw.writeU8(this.decimals);
+    bw.writeU8(this.version || 1);
 
     return bw.render();
   }
@@ -280,7 +292,8 @@ class SlpCoinRecord {
       name: this.name,
       uri: this.uri,
       hash: this.hash,
-      decimals: this.decimals
+      decimals: this.decimals,
+      version: this.version || 1
     }
     return json;
   }
@@ -299,6 +312,7 @@ class SlpCoinRecord {
     this.uri = json.uri;
     this.hash = json.hash
     this.decimals = json.decimals;
+    this.version = json.version;
 
     return this
   }
@@ -369,6 +383,7 @@ class SLP extends Script {
 
     // Check version
     if (script.getString(2, 'hex') != '01')
+    // if (script.getString(2, 'hex') != '01' && script.getString(2, 'hex') != '02')
       return false;
 
     // Type
@@ -555,8 +570,9 @@ class SLP extends Script {
 
     const records = [];
     // Create TokenRecord
-    records.push(this.constructor.TokenRecord({
-      tokenId,
+    records.push(this.constructor.TokenRecord({      
+      tokenId,      
+      version: this.getInt(2),
       ticker: this.getString(4, 'utf-8'),
       name: this.getString(5, 'utf-8'),
       uri: this.getString(6, 'utf-8'),
@@ -569,7 +585,8 @@ class SLP extends Script {
       vout: 1,
       tokenId,
       value: this.getData(10),
-      type
+      type,
+      version: this.getInt(2)
     }));
     // Create Mint Baton SLPCoinRecord
     if (this.getInt(9) >= 2) {
@@ -580,7 +597,8 @@ class SLP extends Script {
         vout: this.getInt(9),
         tokenId,
         value: valBuf,
-        type: 'BATON'
+        type: 'BATON',
+        version: this.getInt(2)
       }));
     }
     return records;
@@ -606,7 +624,8 @@ class SLP extends Script {
       vout: 1,
       tokenId: this.getData(4),
       value: this.getData(6),
-      type
+      type,
+      version: this.getInt(2)
     }));
     // Create Mint Baton SLPCoinRecord
     if (this.getInt(5) >= 2) {
@@ -616,7 +635,8 @@ class SLP extends Script {
         vout: this.getInt(5),
         tokenId: this.getData(4),
         value: valBuf,
-        type: 'BATON'
+        type: 'BATON',
+        version: this.getInt(2)
       }));
     }
     return records;
@@ -648,7 +668,8 @@ class SLP extends Script {
         vout,
         tokenId: this.getData(4),
         value: valueBuf,
-        type
+        type,
+        version: this.getInt(2)
       }));
     }
     return records;
@@ -669,7 +690,8 @@ class SLP extends Script {
       vout: 0,
       tokenId: this.getData(4),
       value: valueBuf,
-      type
+      type,
+      version: this.getInt(2)
     }));
 
     return records;
@@ -710,6 +732,7 @@ class SLP extends Script {
    * @param {String?} uri
    * @param {String?} hash
    * @param {Number} decimals
+   * @param {Number?} version
    * @returns {TokenRecord}
    */
 
@@ -725,6 +748,7 @@ class SLP extends Script {
    * @param {Buffer?} tokenIndex 4 byte unsigned integer (index of tx hash in db)
    * @param {Number} value
    * @param {String} type GENESIS | MINT | SEND | BATON
+   * @param {Number?} version
    * @returns {SlpCoinRecord}
    */
 


### PR DESCRIPTION
Previous addition of the version property to SlpCoinRecord has been copied to TokenRecord. Constructors of both, SlpCoinRecord and TokenRecord, called in SLP class are now using the token type property parsed from script. Current changes  add version property to TokenRecord but do not allow for version 2 unless version check in verifySlp is replaced. 